### PR TITLE
Dockerize provided Node app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:16
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY ./src/*.js ./
+COPY ./bin/* ./bin/
+
+EXPOSE 3000
+
+CMD [ "node", "000.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:16
 
+ENV SECRET_WORD=TwelveFactor
+
 WORKDIR /usr/src/app
 
 COPY package*.json ./


### PR DESCRIPTION
This PR implements a Dockerfile for the prvided Node app, including the inclusion of the `SECRET_WORD` environment value, which was determined during first-round testing of the Docker container. It exposes the app on port 3000.